### PR TITLE
Fix some typos on the evaluation page

### DIFF
--- a/templates/html/summary/report.html.twig
+++ b/templates/html/summary/report.html.twig
@@ -128,7 +128,7 @@
                         This score is not absolute. This chart is a comparison of your project relative to a representative average of recent PHP projects.
                     </p>
                     <p>
-                        Each score is calculated from <acronym title="Cyclomatic complexity, Halstead metrics, Maintenability Index, Comment weight, Difficulty, Logical lines of code...">various criterias</acronym> from {{ results |length }} files in your projects.
+                        Each score is calculated from <acronym title="Cyclomatic complexity, Halstead metrics, Maintenability Index, Comment weight, Difficulty, Logical lines of code...">various criteria</acronym> from {{ results |length }} files in your projects.
                         Your score is a note between 0 (poor) and {{ constant('Hal\\Application\\Score\\Scoring::MAX') }} (excellent).
                     </p>
                     <table class="table">
@@ -148,7 +148,7 @@
                         </tbody>
                     </table>
                     <p>
-                        <strong>This score does not replace the judgment of an human.</strong>
+                        <strong>This score does not replace the judgement of a human.</strong>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Fixes typos in 'criterias', 'judgement' and the grammar for 'a human'.