### PR TITLE
Fix #86 add generated time of html report

### DIFF
--- a/templates/html/summary/report.html.twig
+++ b/templates/html/summary/report.html.twig
@@ -296,6 +296,7 @@
 
     <div class="row">
         Powered by <a href="http://www.phpmetrics.org">PhpMetrics</a> - Copyright Jean-François Lépine
+        <br/> Generated on {{"now"|date('jS \\o\\f F Y \\a\\t h:i:s A')}}
     </div>
 
 


### PR DESCRIPTION
I've added something like this:
![date_metrics](https://cloud.githubusercontent.com/assets/1098293/6155186/3308422a-b229-11e4-9006-81c1229a86e3.png)

Hope you like it. I can put it elsewhere if you wish :)