### PR TITLE
Fix color may be not initialized

### DIFF
--- a/src/Hal/Application/Formater/Chart/Bubbles.php
+++ b/src/Hal/Application/Formater/Chart/Bubbles.php
@@ -67,7 +67,7 @@ class Bubbles implements FormaterInterface {
                 case Validator::CRITICAL:   $color = 'red'; break;
                 case Validator::GOOD:       $color = 'chartreuse4'; break;
                 case Validator::WARNING:    $color = 'gold1'; break;
-                case Validator::UNKNOWN:    $color = 'grey'; break;
+                default:                    $color = 'grey'; break;
             }
 
             // size


### PR DESCRIPTION
In order to be safer we should add the default making a ```$color``` variable to always be initialized.

Scrutinizer-ci issue: 
> The variable $color does not seem to be defined for all execution paths leading up to this point.