### PR TITLE
Class without parent should return null as parent class

### DIFF
--- a/src/Hal/Component/OOP/Reflected/ReflectedClass.php
+++ b/src/Hal/Component/OOP/Reflected/ReflectedClass.php
@@ -175,9 +175,12 @@ class ReflectedClass {
     /**
      * Get the parent name
      *
-     * @return string
+     * @return string|null null when no parent class exists
      */
     public function getParent() {
+        if ($this->parent === null) {
+            return null;
+        }
         return $this->nameResolver->resolve($this->parent, $this->getNamespace());
     }
 };

--- a/tests/Hal/Component/OOP/OOPExtractorTest.php
+++ b/tests/Hal/Component/OOP/OOPExtractorTest.php
@@ -74,4 +74,15 @@ class OOPExtractorTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    public function testClassesThatDoesNotExtendOtherClassesShouldNotHaveAParentClass()
+    {
+        $file = __DIR__.'/../../../resources/oop/f1.php';
+        $extractor = new Extractor(new \Hal\Component\Token\Tokenizer());
+        $result = $extractor->extract($file);
+        $this->assertCount(1, $result->getClasses());
+
+        $class = current($result->getClasses());
+        $this->assertNull($class->getParent());
+    }
+
 }


### PR DESCRIPTION
Actual a class without a parent class returns its namespace because of the usage of the `$nameResolver->resolve()`. This causes wrong dependencies in the [HtmlFormatter](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/src/Hal/Application/Formater/Summary/Html.php#L96).