### PR TITLE
Always use fqcn for class names.

### DIFF
--- a/src/Hal/Application/Formater/Summary/Html.php
+++ b/src/Hal/Application/Formater/Summary/Html.php
@@ -89,8 +89,8 @@ class Html implements FormaterInterface {
             }
 
             foreach($item->getOOP()->getClasses() as $class) {
-                $array[$class->getName()] = (object) array(
-                    'name' => $class->getName()
+                $array[$class->getFullname()] = (object) array(
+                    'name' => $class->getFullname()
                     , 'size' => 3000
                     , 'relations' => array_merge(
                         !is_null($class->getParent()) ? array($class->getParent()) : array()


### PR DESCRIPTION
Otherwise most classes would exists two times within the dependency graph: once with short name and once with fqcn.