### PR TITLE
Not imported classes / NameResolver handles unknown namespace

### DIFF
--- a/src/Hal/Component/OOP/Resolver/NameResolver.php
+++ b/src/Hal/Component/OOP/Resolver/NameResolver.php
@@ -51,6 +51,9 @@ class NameResolver
             }
         }
 
+        if ($currentNamespace === null) {
+            return $name;
+        }
         return rtrim($currentNamespace, '\\').'\\'.$name;
 
     }

--- a/tests/Hal/Component/OOP/MethodExtractorTest.php
+++ b/tests/Hal/Component/OOP/MethodExtractorTest.php
@@ -147,8 +147,8 @@ EOT;
     public function provideCodeForNew() {
         return array(
             array(array(), '<?php public function foo() { return 1; }')
-            , array(array('\A'), '<?php public function bar() { new A();  }')
-            , array(array('\A'), '<?php public function bar() { new A(1,2,3);  }')
+            , array(array('A'), '<?php public function bar() { new A();  }')
+            , array(array('A'), '<?php public function bar() { new A(1,2,3);  }')
             , array(array(), '<?php public function bar($d = false) {  }')
             , array(array(), '<?php public function bar($d = false) {  }')
         );

--- a/tests/Hal/Component/OOP/OOPExtractorTest.php
+++ b/tests/Hal/Component/OOP/OOPExtractorTest.php
@@ -55,7 +55,7 @@ class OOPExtractorTest extends \PHPUnit_Framework_TestCase {
     public function providesForDependenciesWithoutAlias() {
         return array(
             array(__DIR__.'/../../../resources/oop/f7.php', array('Symfony\Component\Config\Definition\Processor'))
-            , array(__DIR__.'/../../../resources/oop/f4.php', array('\Full\AliasedClass', '\Toto'))
+            , array(__DIR__.'/../../../resources/oop/f4.php', array('\Full\AliasedClass', '\My\Example\Toto'))
         );
     }
 
@@ -68,7 +68,7 @@ class OOPExtractorTest extends \PHPUnit_Framework_TestCase {
         $class = $classes[0];
         $dependencies = $class->getDependencies();
 
-        $expected = array('\Example\IAmCalled', '\IAmCalled');
+        $expected = array('\Example\IAmCalled', '\My\Example\IAmCalled');
 
         $this->assertEquals($expected, $dependencies, 'Direct dependencies (calls) are found');
 

--- a/tests/Hal/Component/OOP/Resolver/NameResolverTest.php
+++ b/tests/Hal/Component/OOP/Resolver/NameResolverTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Test\Hal\Component\OOP\Resolver;
+
+use Hal\Component\OOP\Resolver\NameResolver;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class NameResolverTest extends TestCase
+{
+    /** @var NameResolver */
+    private $resolver;
+
+    protected function setUp()
+    {
+        $this->resolver = new NameResolver();
+    }
+
+    public function testAlreadyNamespacedClassNamesShouldNotBeChanged()
+    {
+        $this->assertSame('\\foo\\bar', $this->resolver->resolve('\\foo\\bar'));
+    }
+
+    public function testAliasedClassesShouldBeResolvedToItsOriginalFQCN()
+    {
+        $this->resolver->pushAlias((object) array('alias' => 'baz', 'name' => '\\foo\\bar'));
+        $this->assertSame('\\foo\\bar', $this->resolver->resolve('baz'));
+    }
+
+    public function testUsedClassesShouldBeResolvedToItsOriginalFQCN()
+    {
+        $this->resolver->pushAlias((object) array('alias' => '\\foo\\bar', 'name' => '\\foo\\bar'));
+        $this->assertSame('\\foo\\bar', $this->resolver->resolve('bar'));
+    }
+
+    public function testClassesThatAreNotUsedShouldBelongToTheCurrentNamespace()
+    {
+        $this->assertSame('\\foo\\bar', $this->resolver->resolve('bar', '\\foo'));
+        $this->assertSame('\\foo\\bar', $this->resolver->resolve('bar', '\\foo\\'));
+        $this->assertSame('\\baz', $this->resolver->resolve('baz'));
+    }
+}

--- a/tests/Hal/Component/OOP/Resolver/NameResolverTest.php
+++ b/tests/Hal/Component/OOP/Resolver/NameResolverTest.php
@@ -37,4 +37,9 @@ class NameResolverTest extends TestCase
         $this->assertSame('\\foo\\bar', $this->resolver->resolve('bar', '\\foo\\'));
         $this->assertSame('\\baz', $this->resolver->resolve('baz'));
     }
+
+    public function testTheNameResolverShouldNotResolveTheNamespaceOfNotUsedClassesWhenNoNamespaceIsKnown()
+    {
+        $this->assertSame('baz', $this->resolver->resolve('baz', null));
+    }
 }


### PR DESCRIPTION
Actual when a class, that is used within a method, is not imported by a `use`-statement, this classes are resolved as if they belong to the global namespace (see [OOPExtractorTest#40-60](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/tests/Hal/Component/OOP/OOPExtractorTest.php#L40-60) and [f4.php](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/tests/resources/oop/f4.php) and also [OOPExtractorTest#62-75](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/tests/Hal/Component/OOP/OOPExtractorTest.php#L62-75) and [f5.php](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/tests/resources/oop/f5.php). But instead they should be resolved as if they belong to the current namespace.
The PR changes this behavior.

Therefor I needed to change the NameResolver. Actual when the dependencies are fetched from a class, the NameResolver will resolve the dependencies within the class (knowing the namespace of the class, see [ReflectedClass#129](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/src/Hal/Component/OOP/Reflected/ReflectedClass.php#L129)) and before that the class will also be resolved within the method (without knowing the namespace, see [ReflectedMethod#223](https://github.com/Halleck45/PhpMetrics/blob/6ef089ab9179e766a426836cdff078ee0556373c/src/Hal/Component/OOP/Reflected/ReflectedMethod.php#L223)).

This is how an unimported class will be resolved actual:

| Namespace of the method | Class name used within the method | Class name after resolving within ReflectedMethod | Class name after resolving within ReflectedClass |
|-------------------------|-----------------------------------|---------------------------------------------------|--------------------------------------------------|
| My | Example | \Example | \Example |

And this is how an unimported class will be resolved with this pr:

| Namespace of the method | Class name used within the method | Class name after resolving within ReflectedMethod | Class name after resolving within ReflectedClass |
|-------------------------|-----------------------------------|---------------------------------------------------|--------------------------------------------------|
| My | Example | Example | My\Example |