### PR TITLE
composer: min PHP 5.4 added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         }
     },
     "require": {
+        "php": ">=5.4",
         "twig/twig": "~1.15",
         "symfony/console": "~2.4",
         "hoa/ruler": "~1.0",


### PR DESCRIPTION
According to https://github.com/Halleck45/PhpMetrics/commit/23a7b9a49ca8824afc685e845fd4262cd89c3344, looks like min version is PHP 5.4