### PR TITLE
Fixes #163 - Some dependencies are not visible on Hierarchical graph

### DIFF
--- a/templates/html/summary/report-relations.js.twig
+++ b/templates/html/summary/report-relations.js.twig
@@ -93,6 +93,7 @@
             var map = {};
 
             function find(name, data) {
+                name = (data ? name + ' ' : name);
                 var node = map[name], i;
                 if (!node) {
                     node = map[name] = data || {name: name, children: []};


### PR DESCRIPTION
This feels like a hack fix, but I couldn't find another solution.

The Hierarchical Edge Bundling is not prepared for namespaces/packages which are also classes.

Making the class names a little different from namespaces (by adding a space) fixes the problem.