### PR TITLE
Fix evaluation graph width

### DIFF
--- a/templates/html/summary/report-score.js.twig
+++ b/templates/html/summary/report-score.js.twig
@@ -16,10 +16,12 @@
         ];
 
         var chart = RadarChart.chart();
-        chart.config({maxValue: 100})
-        var svg = d3.select('#chart-score').append('svg')
-                .attr('width', 500)
-                .attr('height', 500);
+        chart.config({
+            maxValue: 100,
+            w: 500,
+            h: 500
+        });
+        var svg = d3.select('#chart-score').append('svg');
 
         // darw one
         svg.append('g').classed('focus', 1).datum(score).call(chart);


### PR DESCRIPTION
This   fixes a tiny bug with the width of the evaluation graph (check the screenshot)
![metrics_evaluation_bug](https://cloud.githubusercontent.com/assets/1098293/11660691/41ec2ba6-9dc6-11e5-870e-ef974f919942.png)
